### PR TITLE
Refactor paths.rs

### DIFF
--- a/src/storage/paths.rs
+++ b/src/storage/paths.rs
@@ -1,29 +1,42 @@
-#[cfg(target_os = "windows")]
+/// Exits at compile-time or panics if no suitable OS found.
+/// (suitable = {windows,macos,unix})
+fn no_os_found() -> ! {
+    // Maybe use a temporary local directory, here?
+
+    // This fails at compile-time.
+    #[cfg(not(any(target_os = "macos", unix, windows)))]
+    compile_error!("OS not detected!");
+
+    // If somehow, it doesn't, we panic.
+    panic!("OS not detected!");
+}
+
+/// Returns an OS specific persistent directory to store app data.
+///
+/// Also, maybe consider returning a &Path instead of a &str.
 pub fn persistent_dir() -> &'static str {
-    r"C:\ProgramData\Oxylos\"
+    // MacOS is Unix. And the path is no different.
+    if cfg!(unix) {
+        "/tmp/Oxylos/"
+    } else if cfg!(windows) {
+        r"C:\ProgramData\Oxylos\"
+    } else {
+        no_os_found()
+    }
 }
 
-#[cfg(target_os = "windows")]
+/// Returns an OS specific temporary directory to store app data.
+///
+/// Stores directly on the shm device on unix, on the RAM.
 pub fn ram_dir() -> &'static str {
-    r"Global\Oxylos"
-}
-
-#[cfg(all(unix, not(target_os = "macos")))]
-pub fn persistent_dir() -> &'static str {
-    "/tmp/Oxylos/"
-}
-
-#[cfg(all(unix, not(target_os = "macos")))]
-pub fn ram_dir() -> &'static str {
-    "/dev/shm/Oxylos/"
-}
-
-#[cfg(target_os = "macos")]
-pub fn persistent_dir() -> &'static str {
-    "/tmp/Oxylos/"
-}
-
-#[cfg(target_os = "macos")]
-pub fn ram_dir() -> &'static str {
-    "/tmp/Oxylos.shm/"
+    // MacOS first because MacOS is Unix.
+    if cfg!(target_os = "macos") {
+        "/tmp/Oxylos.shm/"
+    } else if cfg!(unix) {
+        "/dev/shm/Oxylos/"
+    } else if cfg!(windows) {
+        r"Global\Oxylos"
+    } else {
+        no_os_found()
+    }
 }


### PR DESCRIPTION
## Contents

This PR refactors the `src/storage/paths.rs` file so that only one of each function definition exists, and that no duplicates exist; instead of having three almost-identical `persistent_dir()` and another three `ram_dir()` functions.

It is an arguable decision because, in the original design, the different functions were chosen by the compiler to be in the final binary, but this PR's design does a check.
However, in my opinion, this design is a little more readable and easier to maintain in the long-run.

## Tests

I haven't tested the full code, as it does not compile on my machine (which is cursed).

But I have stripped out the file and tested it standalone, and it compiles, and seems to function properly.